### PR TITLE
Fix invalid JSON in package.json (missing comma in dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://youtube.com/@anandev"
   },
   "dependencies": {
-    "com.unity.splines": "2.7.2"
+    "com.unity.splines": "2.7.2",
     "com.unity.formats.fbx": "5.1.5"
   },
   "repository": {


### PR DESCRIPTION
Error when importing via git url in unity package manager, it worked after adding the comma. please test, thanks
 -----
 Error message
[Package Manager Window] Error adding package: git@github.com:AnanD3V/SplineMesh.git. Unable to add package [git@github.com:AnanD3V/SplineMesh.git]:
  The file [/Users/joelcamilofernandes/Documents/Unity Projects/Honey Valley/Library/PackageCache/@403d382bf8/package.json] is not valid JSON:
    Unexpected string in JSON at position 653 while parsing '{
      "name": "com.anandev.splinemesh",
      '
UnityEditor.EditorApplication:Internal_CallUpdateFunctions () (at /Users/bokken/build/output/unity/unity/Editor/Mono/EditorApplication.cs:380)
------
